### PR TITLE
Fix DeepSeek schema incompatibility

### DIFF
--- a/packages/core/src/core/openAICompatibleContentGenerator.ts
+++ b/packages/core/src/core/openAICompatibleContentGenerator.ts
@@ -9,12 +9,14 @@ import {
   Part,
   ContentListUnion,
   PartUnion,
+  Schema,
 } from '@google/genai';
 import OpenAI from 'openai';
 import { ContentGenerator } from './contentGenerator.js';
 import { jsonrepair } from 'jsonrepair';
 
 import { reportError } from '../utils/errorReporting.js';
+import { SchemaValidator } from '../utils/schemaValidator.js';
 
 export function baseURL(): string {
   return process.env.SILICONFLOW_BASE_URL || 'https://api.siliconflow.cn';
@@ -235,8 +237,9 @@ export class OpenAICompatibleContentGenerator implements ContentGenerator {
                 function: {
                   name: func.name,
                   description: func.description || '',
-                  parameters:
-                    (func.parameters as Record<string, unknown>) || {},
+                  parameters: SchemaValidator.toJsonSchema(
+                    func.parameters as unknown as Schema,
+                  ),
                 },
               };
             }) || []

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -26,7 +26,7 @@ export class SchemaValidator {
     if (typeof data !== 'object' || data === null) {
       return 'Value of params must be an object';
     }
-    const validate = ajValidator.compile(this.toObjectSchema(schema));
+    const validate = ajValidator.compile(this.toJsonSchema(schema));
     const valid = validate(data);
     if (!valid && validate.errors) {
       return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
@@ -39,18 +39,18 @@ export class SchemaValidator {
    * This is necessary because it represents Types as an Enum (with
    * UPPERCASE values) and minItems and minLength as strings, when they should be numbers.
    */
-  private static toObjectSchema(schema: Schema): object {
+  static toJsonSchema(schema: Schema): object {
     const newSchema: Record<string, unknown> = { ...schema };
     if (newSchema.anyOf && Array.isArray(newSchema.anyOf)) {
-      newSchema.anyOf = newSchema.anyOf.map((v) => this.toObjectSchema(v));
+      newSchema.anyOf = newSchema.anyOf.map((v) => this.toJsonSchema(v));
     }
     if (newSchema.items) {
-      newSchema.items = this.toObjectSchema(newSchema.items);
+      newSchema.items = this.toJsonSchema(newSchema.items);
     }
     if (newSchema.properties && typeof newSchema.properties === 'object') {
       const newProperties: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(newSchema.properties)) {
-        newProperties[key] = this.toObjectSchema(value as Schema);
+        newProperties[key] = this.toJsonSchema(value as Schema);
       }
       newSchema.properties = newProperties;
     }


### PR DESCRIPTION
## Summary
- expose SchemaValidator.toJsonSchema helper
- convert function schemas for OpenAI-compatible requests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd2f8969c8329bc7dbc828bfc3254