### PR TITLE
fix(core): handle unknown parametersJsonSchema

### DIFF
--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -306,7 +306,9 @@ export class ToolRegistry {
     this.tools.forEach((tool) => {
       const schema = tool.schema;
       const parameters = lowercaseSchemaTypes(schema.parameters);
-      const parametersJson = lowercaseSchemaTypes(schema.parametersJsonSchema);
+      const parametersJson = lowercaseSchemaTypes(
+        schema.parametersJsonSchema as Schema | boolean | undefined,
+      );
       declarations.push({
         ...schema,
         parameters: parameters as Schema | undefined,


### PR DESCRIPTION
## Summary
- make tool registry cast `parametersJsonSchema` to a Schema

## Testing
- `npm run preflight` *(fails: Cannot find package 'glob')*

------
https://chatgpt.com/codex/tasks/task_e_687fddd2804483299e8eed95959bc958